### PR TITLE
Refactor/gatherings

### DIFF
--- a/app/(gathering)/components/MyGatherings.tsx
+++ b/app/(gathering)/components/MyGatherings.tsx
@@ -1,4 +1,5 @@
 import Gathering from "@/app/(home)/components/Gathering";
+import GatheringsWrapper from "@/app/components/common/GatheringsWrapper";
 import { useMyGatheringsStore } from "@/app/store/store";
 
 interface MyGatheringsProps {
@@ -10,7 +11,7 @@ export default function MyGatherings({ isLogin }: MyGatheringsProps) {
   const myGatherings = useMyGatheringsStore((state) => state.myGatherings);
 
   return (
-    <div className="px-auto grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-y-6 py-2 px-12 md:px-3 mx-auto">
+    <GatheringsWrapper>
       {myGatherings?.map((gathering) => {
         return (
           <Gathering
@@ -26,6 +27,6 @@ export default function MyGatherings({ isLogin }: MyGatheringsProps) {
           />
         );
       })}
-    </div>
+    </GatheringsWrapper>
   );
 }

--- a/app/(home)/components/Gathering.tsx
+++ b/app/(home)/components/Gathering.tsx
@@ -86,7 +86,7 @@ export default function Gathering({
       />
       <CardHeader className="relative p-0 py-2 my-3 cursor-pointer">
         <CardTitle>{title}</CardTitle>
-        <LikeButton id={id} date={date} onDelete={onDelete ?? undefined} />
+        <LikeButton id={id} date={date} onDelete={onDelete} />
         <div className="flex justify-between items-center cursor-pointer">
           <CardDescription>{newDate}</CardDescription>
           <CardDescription>{user}</CardDescription>

--- a/app/(home)/components/Gathering.tsx
+++ b/app/(home)/components/Gathering.tsx
@@ -10,12 +10,7 @@ import {
 } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { stopBubbling } from "@/app/util";
-import {
-  generateMap,
-  generateMarker,
-  generateKakaoScript,
-  getDate,
-} from "../util";
+import { loadKakaoAPI, generateKakaoScript, getDate } from "../util";
 import LikeButton from "./LikeButton";
 import { usePopupStore } from "@/app/store/store";
 
@@ -57,20 +52,11 @@ export default function Gathering({
 
   useEffect(() => {
     const kakaoMapScript = generateKakaoScript();
-
-    const onLoadKakaoAPI = () => {
-      window.kakao.maps.load(() => {
-        const map = generateMap(id, lat, lng);
-        const marker = generateMarker(map);
-
-        marker.setMap(map);
-      });
-    };
-
-    kakaoMapScript.addEventListener("load", onLoadKakaoAPI);
+    const onLoad = () => loadKakaoAPI(id, lat, lng);
+    kakaoMapScript.addEventListener("load", onLoad);
 
     return () => {
-      kakaoMapScript.removeEventListener("load", onLoadKakaoAPI);
+      kakaoMapScript.removeEventListener("load", onLoad);
     };
   }, [id, lat, lng]);
 

--- a/app/(home)/components/GatheringDetail.tsx
+++ b/app/(home)/components/GatheringDetail.tsx
@@ -11,12 +11,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { stopBubbling } from "@/app/util";
-import {
-  generateKakaoScript,
-  generateMap,
-  generateMarker,
-  getDate,
-} from "../util";
+import { generateKakaoScript, getDate, loadKakaoAPI } from "../util";
 
 export interface GatheringDetailProps {
   _id: string;
@@ -49,21 +44,13 @@ export default function GatheringDetail({
 
   useEffect(() => {
     const kakaoMapScript = generateKakaoScript();
+    const newId = _id.concat("1");
+    const onLoad = () => loadKakaoAPI(newId, lat, lng);
 
-    const onLoadKakaoAPI = () => {
-      window.kakao.maps.load(() => {
-        const id = _id.concat("1");
-        const map = generateMap(id, lat, lng);
-        const marker = generateMarker(map);
-
-        marker.setMap(map);
-      });
-    };
-
-    kakaoMapScript.addEventListener("load", onLoadKakaoAPI);
+    kakaoMapScript.addEventListener("load", onLoad);
 
     return () => {
-      kakaoMapScript.removeEventListener("load", onLoadKakaoAPI);
+      kakaoMapScript.removeEventListener("load", onLoad);
     };
   }, [_id, lat, lng]);
 

--- a/app/(home)/components/Gatherings.tsx
+++ b/app/(home)/components/Gatherings.tsx
@@ -5,6 +5,7 @@ import { WithId } from "mongodb";
 import PageButton from "@/app/(home)/components/PageButton";
 import Gathering from "./Gathering";
 import { IGathering } from "../types/type";
+import GatheringsWrapper from "@/app/components/common/GatheringsWrapper";
 
 export default function Gatherings({
   isLogin,
@@ -22,7 +23,7 @@ export default function Gatherings({
   return (
     <>
       <PageButton onChange={handleChangePages} />
-      <div className="px-auto grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-y-6 py-2 px-12 md:px-3 mx-auto">
+      <GatheringsWrapper>
         {gatherings.map((gathering) => {
           return (
             <Gathering
@@ -37,7 +38,7 @@ export default function Gatherings({
             />
           );
         })}
-      </div>
+      </GatheringsWrapper>
     </>
   );
 }

--- a/app/(home)/util/index.ts
+++ b/app/(home)/util/index.ts
@@ -10,7 +10,7 @@ export const generateKakaoScript = () => {
   return kakaoMapScript;
 };
 
-export const generateMap = (
+const generateMap = (
   id: string,
   lat: number,
   lng: number,
@@ -27,7 +27,7 @@ export const generateMap = (
   return map;
 };
 
-export const generateMarker = <T extends { getCenter: () => void }>(map: T) => {
+const generateMarker = <T extends { getCenter: () => void }>(map: T) => {
   const marker = new kakao.maps.Marker({
     map,
     position: map.getCenter(),

--- a/app/(home)/util/index.ts
+++ b/app/(home)/util/index.ts
@@ -36,6 +36,47 @@ export const generateMarker = <T extends { getCenter: () => void }>(map: T) => {
   return marker;
 };
 
+export const loadKakaoAPI = (id: string, lat: number, lng: number) => {
+  window.kakao.maps.load(() => {
+    const map = generateMap(id, lat, lng);
+    const marker = generateMarker(map);
+
+    marker.setMap(map);
+  });
+};
+
+export const loadKakaoAPIWithForm = (
+  id: string,
+  lat: number,
+  lng: number,
+  callback: (lat: string, lng: string) => void,
+) => {
+  window.kakao.maps.load(() => {
+    const map = generateMap(id, lat, lng);
+    const marker = generateMarker(map);
+
+    marker.setMap(map);
+
+    kakao.maps.event.addListener(
+      map,
+      "click",
+      <
+        T extends {
+          latLng: { getLat: () => number; getLng: () => number };
+        },
+      >(
+        mouseEvent: T,
+      ) => {
+        const latlng = mouseEvent.latLng;
+
+        marker.setPosition(latlng);
+
+        callback(latlng.getLat().toString(), latlng.getLng().toString());
+      },
+    );
+  });
+};
+
 export const getDate = (data: Date) => {
   return new Intl.DateTimeFormat("ko-KR", {
     year: "numeric",

--- a/app/components/common/GatheringsWrapper.tsx
+++ b/app/components/common/GatheringsWrapper.tsx
@@ -1,0 +1,9 @@
+import { PropsWithChildren } from "react";
+
+export default function GatheringsWrapper({ children }: PropsWithChildren) {
+  return (
+    <div className="px-auto grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-y-6 py-2 px-12 md:px-3 mx-auto">
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
### 작업 내용

- gatherings관련 리팩터링
- 컴포넌트 분리 및 추상화
- 구현상세 추상화

### 특징

리팩토링은 [Frontend Fundamentals](https://frontend-fundamentals.com/)를 참조하여 진행합니다.

#### 구현 상세 추상화

1. 지도 관련 코드 추상화
- useEffect내에서 지도를 로드하고 불러내는 모든 코드가 들어날 필요가 없다고 생각했습니다.
- 이를 위해 코드를 추상화 하고, 분리했습니다.
- 덕부에 지도를 만들어내는 코드나 marker를 만들어내는 코드는 Module 내부에서 관리할 수 있게 되었습니다.

2. wrapper 컴포넌트 추상화 및 분리
- Gathering을 불러오는 코드 역시 따로 관리해도 된다 판단했습니다.
- 따로 중요한 로직은 없으나, tailwindCss를 사용하기 때문에 classname에 관하여 굳이 오픈할 필요가 없다 판단하고 분리했습니다.

#### 중복 코드 허용

- 지도 관련 코드 분리 시, 추상화와 일반화를 통해 하나로 관리할 지,  중복 코드를 허용해서 관리할 지 고민했습니다.
- 일반화를 할 경우 전달하는 callback을 그대로 노출시켜야 합니다. 

```js
// 예시
// util.js
const exampleFn = (x, y, z, fn) => {
  //...중략
  if (fn) {
    fn()
  }
}

//Component

export default function Component() {
  const [state, setState] = useState();

  useEffect(() => {
     exampleFn(a, b, c, () => {
        setState(p => p + a + b / c);
     });
  })
}
```

여기서 컴포넌트는 jsx를 return하는 함수일 뿐이고, 과도한 추상화로 구현상세를 노출할 필요가 없다 생각했습니다.
그래서 Util 함수에서 중복 코드를 허용해서 전달되는 함수를 최소화하는 코드로 전환했습니다. 

```js
// 예시
// util.js
const exampleFn = (x, y, z, fn) => {
  //...중략
  if (fn) {
    fn(x, y)
  }
}

//Component

export default function Component() {
  const [state, setState] = useState();

  useEffect(() => {
     exampleFn(a, b, c, setState);
  })
}
```